### PR TITLE
Lower Memory Usage

### DIFF
--- a/burstphoto/align.metal
+++ b/burstphoto/align.metal
@@ -240,6 +240,18 @@ kernel void add_texture(texture2d<float, access::read> in_texture [[texture(0)]]
     out_texture.write(color_value, gid);
 }
 
+kernel void add_crop(texture2d<float, access::read> in_texture [[texture(0)]],
+                     texture2d<float, access::read_write> out_texture [[texture(1)]],
+                     constant int& x_offset [[buffer(0)]],
+                     constant int& y_offset [[buffer(1)]],
+                     uint2 gid [[thread_position_in_grid]]) {
+      
+    int x = gid.x + x_offset;
+    int y = gid.y + y_offset;
+  
+    float color_value = in_texture.read(uint2(x, y)).r + out_texture.read(gid).r;
+    out_texture.write(color_value, gid);
+}
 
 kernel void copy_texture(texture2d<float, access::read> in_texture [[texture(0)]],
                          texture2d<float, access::write> out_texture [[texture(1)]],

--- a/burstphoto/align.swift
+++ b/burstphoto/align.swift
@@ -88,6 +88,13 @@ struct FrequencyMergeTextureBuffers {
     let comp_pyramid: Array<MTLTexture>
 }
 
+struct PyramidInfo {
+    let tile_sizes: Array<Int>
+    let search_dist: Array<Int>
+    let downscale_factors: Array<Int>
+    let tile_factor: Int
+}
+
 // class to store the progress of the align+merge
 class ProcessingProgress: ObservableObject {
     @Published var int = 0
@@ -461,13 +468,6 @@ func generate_pyramid_buffers(with_metadata_from ref_texture: MTLTexture, with_p
     }
     
     return (_ref_pyramid, _comp_pyramid)
-}
-
-struct PyramidInfo {
-    let tile_sizes: Array<Int>
-    let search_dist: Array<Int>
-    let downscale_factors: Array<Int>
-    let tile_factor: Int
 }
 
 func create_downscaling_pyramid_info(ref_texture: MTLTexture, mosaic_pattern_width: Int, tile_size: Int, search_distance: Int) -> PyramidInfo {
@@ -1393,10 +1393,6 @@ func forward_ft(_ in_texture: MTLTexture, save_in out_texture_ft: MTLTexture, _ 
 
 func backward_ft(_ in_texture_ft: MTLTexture, save_in out_texture: MTLTexture, _ tmp_texture_ft: MTLTexture, _ tile_info: TileInfo, _ n_textures: Int, mode: String) {
     
-//    let out_texture_descriptor = MTLTextureDescriptor.texture2DDescriptor(pixelFormat: .rgba32Float, width: in_texture_ft.width/2, height: in_texture_ft.height, mipmapped: false)
-//    out_texture_descriptor.usage = [.shaderRead, .shaderWrite]
-//    let out_texture = device.makeTexture(descriptor: out_texture_descriptor)!
-    
     let command_buffer = command_queue.makeCommandBuffer()!
     let command_encoder = command_buffer.makeComputeCommandEncoder()!
     // either use discrete Fourier transform or highly-optimized fast Fourier transform
@@ -1412,8 +1408,6 @@ func backward_ft(_ in_texture_ft: MTLTexture, save_in out_texture: MTLTexture, _
     command_encoder.dispatchThreads(threads_per_grid, threadsPerThreadgroup: threads_per_thread_group)
     command_encoder.endEncoding()
     command_buffer.commit()
-    
-//    return out_texture
 }
 
 

--- a/burstphoto/align.swift
+++ b/burstphoto/align.swift
@@ -306,25 +306,9 @@ func perform_denoising(image_urls: [URL], progress: ProcessingProgress, ref_idx:
         var pad_align_y = Int(ceil(Float(texture_height_orig)/Float(tile_factor)))
         pad_align_y = (pad_align_y*Int(tile_factor) - texture_height_orig)/2
         
-        var ref_pyramid:  Array<MTLTexture> = []
-        var comp_pyramid: Array<MTLTexture> = []
-        
-        var width  = textures[ref_idx].width  + 2*pad_align_x + tile_size
-        var height = textures[ref_idx].height + 2*pad_align_y + tile_size
-        for downscale_factor in downscale_factor_array {
-            width  /= downscale_factor
-            height /= downscale_factor
-            let ref_pyramid_texture_descriptor_i = MTLTextureDescriptor.texture2DDescriptor(pixelFormat: textures[ref_idx].pixelFormat, width: width, height: height, mipmapped: false)
-            ref_pyramid_texture_descriptor_i.usage = [.shaderRead, .shaderWrite]
-            let ref_pyramid_texture_i = device.makeTexture(descriptor: ref_pyramid_texture_descriptor_i)!
-            
-            let comp_pyramid_texture_descriptor_i = MTLTextureDescriptor.texture2DDescriptor(pixelFormat: textures[ref_idx].pixelFormat, width: width, height: height, mipmapped: false)
-            comp_pyramid_texture_descriptor_i.usage = [.shaderRead, .shaderWrite]
-            let cmop_pyramid_texture_i = device.makeTexture(descriptor: comp_pyramid_texture_descriptor_i)!
-            
-            ref_pyramid.append(ref_pyramid_texture_i)
-            comp_pyramid.append(cmop_pyramid_texture_i)
-        }
+        let (ref_pyramid, comp_pyramid) = generate_pyramid_buffers(for_ref_texture: textures[ref_idx],
+                                                                   with_downscale_factor_array: downscale_factor_array,
+                                                                   pad_align_x: pad_align_x, pad_align_y: pad_align_y, tile_size: tile_size)
         
         try align_merge_spatial_domain(progress: progress, ref_idx: ref_idx, mosaic_pattern_width: mosaic_pattern_width, search_distance: search_distance_int, tile_size: tile_size, kernel_size: kernel_size, robustness: robustness_norm, textures: textures, final_texture: final_texture, ref_pyramid, comp_pyramid)
     }
@@ -466,6 +450,38 @@ func align_merge_spatial_domain(progress: ProcessingProgress, ref_idx: Int, mosa
     }
 }
 
+/**
+ * Helper function to create buffers needed for generating the pyramids.
+ */
+func generate_pyramid_buffers(for_ref_texture ref_texture: MTLTexture, with_downscale_factor_array downscale_factor_array: Array<Int>, pad_align_x: Int, pad_align_y: Int, tile_size: Int) -> (Array<MTLTexture>, Array<MTLTexture>) {
+    var _ref_pyramid:  Array<MTLTexture> = []
+    var _comp_pyramid: Array<MTLTexture> = []
+    
+    var width  = ref_texture.width  + 2*pad_align_x + tile_size
+    var height = ref_texture.height + 2*pad_align_y + tile_size
+        for downscale_factor in downscale_factor_array {
+            width  /= downscale_factor
+            height /= downscale_factor
+        let ref_pyramid_texture_descriptor_i = MTLTextureDescriptor.texture2DDescriptor(pixelFormat: ref_texture.pixelFormat,
+                                                                                        width: width,
+                                                                                        height: height,
+                                                                                        mipmapped: false)
+        ref_pyramid_texture_descriptor_i.usage = [.shaderRead, .shaderWrite]
+        let ref_pyramid_texture_i = device.makeTexture(descriptor: ref_pyramid_texture_descriptor_i)!
+        
+        let comp_pyramid_texture_descriptor_i = MTLTextureDescriptor.texture2DDescriptor(pixelFormat: ref_texture.pixelFormat,
+                                                                                         width: width,
+                                                                                         height: height,
+                                                                                         mipmapped: false)
+        comp_pyramid_texture_descriptor_i.usage = [.shaderRead, .shaderWrite]
+        let cmop_pyramid_texture_i = device.makeTexture(descriptor: comp_pyramid_texture_descriptor_i)!
+        
+        _ref_pyramid.append(ref_pyramid_texture_i)
+        _comp_pyramid.append(cmop_pyramid_texture_i)
+    }
+    
+    return (_ref_pyramid, _comp_pyramid)
+}
 
 // convenience function for the frequency-based merging approach
 func align_merge_frequency_domain(progress: ProcessingProgress, shift_left_not_right: Bool, shift_top_not_bottom: Bool, ref_idx: Int, mosaic_pattern_width: Int, search_distance: Int, tile_size: Int, tile_size_merge: Int, robustness_norm: Double, read_noise: Double, max_motion_norm: Double, ft_mode: String, textures: [MTLTexture], final_texture: MTLTexture) throws {
@@ -490,11 +506,6 @@ func align_merge_frequency_domain(progress: ProcessingProgress, shift_left_not_r
         res /= 2
         div *= 2
     }
-    
-    let shift_left   = shift_left_not_right ? tile_size_merge : 0
-    let shift_right  = shift_left_not_right ? 0               : tile_size_merge
-    let shift_top    = shift_top_not_bottom ? tile_size_merge : 0
-    let shift_bottom = shift_top_not_bottom ? 0               : tile_size_merge
      
     // calculate padding for extension of the image frame with zeros
     // The minimum size of the frame for the frequency merging has to be texture size + tile_size_merge as 4 frames shifted by tile_size_merge in x, y and x, y are processed in four consecutive runs.
@@ -507,12 +518,6 @@ func align_merge_frequency_domain(progress: ProcessingProgress, shift_left_not_r
     var pad_align_y = Int(ceil(Float(texture_height_orig+tile_size_merge)/Float(tile_factor)))
     pad_align_y = (pad_align_y*Int(tile_factor) - texture_height_orig - tile_size_merge)/2
   
-    // add shifts for artifact suppression
-    let pad_left   = pad_align_x + shift_left
-    let pad_right  = pad_align_x + shift_right
-    let pad_top    = pad_align_y + shift_top
-    let pad_bottom = pad_align_y + shift_bottom
-
     // calculate padding for the merging in the frequency domain, which can be applied to the actual image frame + a smaller margin compared to the alignment
     let crop_merge_x = Int(floor(Float(pad_align_x)/Float(2*tile_size_merge))) * 2 * tile_size_merge
     let crop_merge_y = Int(floor(Float(pad_align_y)/Float(2*tile_size_merge))) * 2 * tile_size_merge
@@ -531,6 +536,17 @@ func align_merge_frequency_domain(progress: ProcessingProgress, shift_left_not_r
         n_pos_2d: 0
     )
     
+    let shift_left   = shift_left_not_right ? tile_size_merge : 0
+    let shift_right  = shift_left_not_right ? 0               : tile_size_merge
+    let shift_top    = shift_top_not_bottom ? tile_size_merge : 0
+    let shift_bottom = shift_top_not_bottom ? 0               : tile_size_merge
+
+    // add shifts for artifact suppression
+    let pad_left   = pad_align_x + shift_left
+    let pad_right  = pad_align_x + shift_right
+    let pad_top    = pad_align_y + shift_top
+    let pad_bottom = pad_align_y + shift_bottom
+    
     let ref_texture_descriptor = MTLTextureDescriptor.texture2DDescriptor(pixelFormat: .r32Float, width:  textures[ref_idx].width + pad_left + pad_right,height: textures[ref_idx].height + pad_top + pad_bottom, mipmapped: false)
     ref_texture_descriptor.usage = [.shaderRead, .shaderWrite]
     let _ref_texture = device.makeTexture(descriptor: ref_texture_descriptor)!
@@ -542,62 +558,63 @@ func align_merge_frequency_domain(progress: ProcessingProgress, shift_left_not_r
     let _aligned_texture = texture_like(_ref_texture)
     fill_with_zeros(_aligned_texture)
     
-    let tmp_texture_ft_descriptor = MTLTextureDescriptor.texture2DDescriptor(pixelFormat: .rgba32Float, width: (texture_width_orig+tile_size_merge+2*pad_merge_x), height: (texture_height_orig+tile_size_merge+2*pad_merge_y)/2, mipmapped: false)
+    let tmp_texture_ft_descriptor = MTLTextureDescriptor.texture2DDescriptor(pixelFormat: .rgba32Float,
+                                                                             width:  (texture_width_orig+tile_size_merge+2*pad_merge_x),
+                                                                             height: (texture_height_orig+tile_size_merge+2*pad_merge_y)/2,
+                                                                             mipmapped: false)
     tmp_texture_ft_descriptor.usage = [.shaderRead, .shaderWrite]
     let _tmp_texture_ft = device.makeTexture(descriptor: tmp_texture_ft_descriptor)!
     
-    let ref_texture_ft_descriptor = MTLTextureDescriptor.texture2DDescriptor(pixelFormat: .rgba32Float, width: (texture_width_orig+tile_size_merge+2*pad_merge_x), height: (texture_height_orig+tile_size_merge+2*pad_merge_y)/2, mipmapped: false)
+    let ref_texture_ft_descriptor = MTLTextureDescriptor.texture2DDescriptor(pixelFormat: .rgba32Float,
+                                                                             width: (texture_width_orig+tile_size_merge+2*pad_merge_x),
+                                                                             height: (texture_height_orig+tile_size_merge+2*pad_merge_y)/2,
+                                                                             mipmapped: false)
     ref_texture_ft_descriptor.usage = [.shaderRead, .shaderWrite]
     let _ref_texture_ft = device.makeTexture(descriptor: ref_texture_ft_descriptor)!
     
-    let aligned_texture_ft_descriptor = MTLTextureDescriptor.texture2DDescriptor(pixelFormat: .rgba32Float, width: (texture_width_orig+tile_size_merge+2*pad_merge_x), height: (texture_height_orig+tile_size_merge+2*pad_merge_y)/2, mipmapped: false)
+    let aligned_texture_ft_descriptor = MTLTextureDescriptor.texture2DDescriptor(pixelFormat: .rgba32Float,
+                                                                                 width: (texture_width_orig+tile_size_merge+2*pad_merge_x),
+                                                                                 height: (texture_height_orig+tile_size_merge+2*pad_merge_y)/2,
+                                                                                 mipmapped: false)
     aligned_texture_ft_descriptor.usage = [.shaderRead, .shaderWrite]
     let _aligned_texture_ft = device.makeTexture(descriptor: aligned_texture_ft_descriptor)!
     
-    let aligned_texture_rgba_descriptor = MTLTextureDescriptor.texture2DDescriptor(pixelFormat: .rgba32Float, width: (_ref_texture.width-2*crop_merge_x)/2, height: (_ref_texture.height-2*crop_merge_y)/2, mipmapped: false)
+    let aligned_texture_rgba_descriptor = MTLTextureDescriptor.texture2DDescriptor(pixelFormat: .rgba32Float,
+                                                                                   width: (_ref_texture.width-2*crop_merge_x)/2,
+                                                                                   height: (_ref_texture.height-2*crop_merge_y)/2,
+                                                                                   mipmapped: false)
     aligned_texture_rgba_descriptor.usage = [.shaderRead, .shaderWrite]
     let _aligned_texture_rgba = device.makeTexture(descriptor: aligned_texture_rgba_descriptor)!
     
-    let ref_texture_rgba_descriptor = MTLTextureDescriptor.texture2DDescriptor(pixelFormat: .rgba32Float, width: (_ref_texture.width-2*crop_merge_x)/2, height: (_ref_texture.height-2*crop_merge_y)/2, mipmapped: false)
+    let ref_texture_rgba_descriptor = MTLTextureDescriptor.texture2DDescriptor(pixelFormat: .rgba32Float,
+                                                                               width: (_ref_texture.width-2*crop_merge_x)/2,
+                                                                               height: (_ref_texture.height-2*crop_merge_y)/2,
+                                                                               mipmapped: false)
     ref_texture_rgba_descriptor.usage = [.shaderRead, .shaderWrite]
     let _ref_texture_rgba = device.makeTexture(descriptor: ref_texture_rgba_descriptor)!
     
-    let final_frequency_texture_descriptor = MTLTextureDescriptor.texture2DDescriptor(
-        pixelFormat: .rgba32Float,
-        width:  (texture_width_orig  + tile_size_merge + 2*pad_merge_x),
-        height: (texture_height_orig + tile_size_merge + 2*pad_merge_y)/2,
-        mipmapped: false)
+    let final_frequency_texture_descriptor = MTLTextureDescriptor.texture2DDescriptor(pixelFormat: .rgba32Float,
+                                                                                      width:  (texture_width_orig  + tile_size_merge + 2*pad_merge_x),
+                                                                                      height: (texture_height_orig + tile_size_merge + 2*pad_merge_y)/2,
+                                                                                      mipmapped: false)
     final_frequency_texture_descriptor.usage = [.shaderRead, .shaderWrite]
     let _final_frequency_texture = device.makeTexture(descriptor: final_frequency_texture_descriptor)!
     fill_with_zeros(_final_frequency_texture)
     
-    let rms_texture_descriptor = MTLTextureDescriptor.texture2DDescriptor(pixelFormat: .rgba32Float, width: tile_info_merge.n_tiles_x, height: tile_info_merge.n_tiles_y, mipmapped: false)
+    let rms_texture_descriptor = MTLTextureDescriptor.texture2DDescriptor(pixelFormat: .rgba32Float,
+                                                                          width: tile_info_merge.n_tiles_x,
+                                                                          height: tile_info_merge.n_tiles_y,
+                                                                          mipmapped: false)
     rms_texture_descriptor.usage = [.shaderRead, .shaderWrite]
     let _rms_rgba_texture = device.makeTexture(descriptor: rms_texture_descriptor)!
     
     // generate texture to accumulate the total mismatch
     let _total_mismatch_rgba_texture = texture_like(_rms_rgba_texture)
     fill_with_zeros(_total_mismatch_rgba_texture)
-    
-    var _ref_pyramid:  Array<MTLTexture> = []
-    var _comp_pyramid: Array<MTLTexture> = []
-    
-    var width  = textures[ref_idx].width  + 2*pad_align_x + tile_size_merge
-    var height = textures[ref_idx].height + 2*pad_align_y + tile_size_merge
-    for downscale_factor in downscale_factor_array {
-        width  /= downscale_factor
-        height /= downscale_factor
-        let ref_pyramid_texture_descriptor_i = MTLTextureDescriptor.texture2DDescriptor(pixelFormat: textures[ref_idx].pixelFormat, width: width, height: height, mipmapped: false)
-        ref_pyramid_texture_descriptor_i.usage = [.shaderRead, .shaderWrite]
-        let ref_pyramid_texture_i = device.makeTexture(descriptor: ref_pyramid_texture_descriptor_i)!
-        
-        let comp_pyramid_texture_descriptor_i = MTLTextureDescriptor.texture2DDescriptor(pixelFormat: textures[ref_idx].pixelFormat, width: width, height: height, mipmapped: false)
-        comp_pyramid_texture_descriptor_i.usage = [.shaderRead, .shaderWrite]
-        let cmop_pyramid_texture_i = device.makeTexture(descriptor: comp_pyramid_texture_descriptor_i)!
-        
-        _ref_pyramid.append(ref_pyramid_texture_i)
-        _comp_pyramid.append(cmop_pyramid_texture_i)
-    }
+
+    let (_ref_pyramid, _comp_pyramid) = generate_pyramid_buffers(for_ref_texture: textures[ref_idx],
+                                                                 with_downscale_factor_array: downscale_factor_array,
+                                                                 pad_align_x: pad_align_x, pad_align_y: pad_align_y, tile_size: tile_size_merge)
     
     let buffers = FrequencyMergeTextureBuffers(
         // Frequency-textures

--- a/burstphoto/align.swift
+++ b/burstphoto/align.swift
@@ -649,13 +649,6 @@ func align_merge_frequency_domain(progress: ProcessingProgress, shift_left_not_r
         // set and extend comparison texture
         extend_texture(textures[comp_idx], onto: buffers.comp_texture, pad.left, pad.top)
         
-        // check that the comparison image has the same resolution as the reference image
-        // TODO: This should to beginning of the application as part of file IO
-        if (buffers.ref_texture.width != buffers.comp_texture.width)
-            || (buffers.ref_texture.height != buffers.comp_texture.height) {
-            throw AlignmentError.inconsistent_resolutions
-        }
-        
         // align comparison texture
         align_texture(buffers.ref_pyramid, buffers.comp_pyramid, buffers.comp_texture, save_in: buffers.aligned_texture, pyramid_info)
         convert_rgba(buffers.aligned_texture, save_in: buffers.aligned_rgba_texture, crop_merge.x, crop_merge.y)

--- a/burstphoto/align.swift
+++ b/burstphoto/align.swift
@@ -174,7 +174,7 @@ func perform_denoising(image_urls: [URL], progress: ProcessingProgress, ref_idx:
         // iterate over all images
         for comp_idx in 0..<image_urls.count {
             
-            add_texture(textures[comp_idx], final_texture, image_urls.count)
+            add_texture(textures[comp_idx], to: final_texture, image_urls.count)
             DispatchQueue.main.async { progress.int += Int(80000000/Double(image_urls.count)) }
         }
         
@@ -318,7 +318,7 @@ func align_merge_spatial_domain(progress: ProcessingProgress, ref_idx: Int, mosa
         
         // add the reference texture to the output
         if comp_idx == ref_idx {
-            add_texture(textures[comp_idx], final_texture, textures.count)
+            add_texture(textures[comp_idx], to: final_texture, textures.count)
             DispatchQueue.main.async { progress.int += Int(80000000/Double(textures.count)) }
             continue
         }
@@ -338,7 +338,7 @@ func align_merge_spatial_domain(progress: ProcessingProgress, ref_idx: Int, mosa
         let merged_texture = robust_merge(textures[ref_idx], ref_texture_blurred, aligned_texture, kernel_size, robustness, noise_sd, mosaic_pattern_width)
         
         // add robust-merged texture to the output image
-        add_texture(merged_texture, final_texture, textures.count)
+        add_texture(merged_texture, to: final_texture, textures.count)
         
         // sync GUI progress
         DispatchQueue.main.async { progress.int += Int(80000000/Double(textures.count)) }
@@ -463,7 +463,7 @@ func align_merge_frequency_domain(progress: ProcessingProgress, shift_left: Int,
         normalize_mismatch(mismatch_texture, mean_mismatch)
            
         // add mismatch texture to the total, accumulated mismatch texture
-        add_texture(mismatch_texture, total_mismatch_texture, textures.count)
+        add_texture(mismatch_texture, to: total_mismatch_texture, textures.count)
         
         // start debug capture
         //let capture_manager = MTLCaptureManager.shared()
@@ -492,7 +492,7 @@ func align_merge_frequency_domain(progress: ProcessingProgress, shift_left: Int,
     let output_texture = crop_texture(convert_bayer(backward_ft(final_texture_ft, tmp_texture_ft, tile_info_merge, textures.count, mode: ft_mode)), pad_left-crop_merge_x, pad_right-crop_merge_x, pad_top-crop_merge_y, pad_bottom-crop_merge_y)
         
     // add output texture to the final texture to collect all textures of the four iterations
-    add_texture(output_texture, final_texture, 1)
+    add_texture(output_texture, to: final_texture, 1)
 }
 
 
@@ -711,7 +711,7 @@ func crop_texture(_ in_texture: MTLTexture, _ pad_left: Int, _ pad_right: Int, _
 }
 
 
-func add_texture(_ in_texture: MTLTexture, _ out_texture: MTLTexture, _ n_textures: Int) {
+func add_texture(_ in_texture: MTLTexture, to out_texture: MTLTexture, _ n_textures: Int) {
     
     let command_buffer = command_queue.makeCommandBuffer()!
     let command_encoder = command_buffer.makeComputeCommandEncoder()!
@@ -1320,7 +1320,7 @@ func correct_hotpixels(_ textures: [MTLTexture]) {
     let average_texture = device.makeTexture(descriptor: average_texture_descriptor)!
     fill_with_zeros(average_texture)
     for texture in textures {
-        add_texture(texture, average_texture, textures.count)
+        add_texture(texture, to: average_texture, textures.count)
     }
     
     // Texture to stores whethere a hot pixel was identifies

--- a/burstphoto/align.swift
+++ b/burstphoto/align.swift
@@ -1319,8 +1319,8 @@ func correct_hotpixels(_ textures: [MTLTexture]) {
     average_texture_descriptor.usage = [.shaderRead, .shaderWrite]
     let average_texture = device.makeTexture(descriptor: average_texture_descriptor)!
     fill_with_zeros(average_texture)
-    for comp_idx in 0..<textures.count {
-        add_texture(textures[comp_idx], average_texture, textures.count)
+    for texture in textures {
+        add_texture(texture, average_texture, textures.count)
     }
     
     // Texture to stores whethere a hot pixel was identifies

--- a/burstphoto/utils.swift
+++ b/burstphoto/utils.swift
@@ -60,6 +60,14 @@ func load_images(_ urls: [URL]) throws -> ([MTLTexture], Int) {
         }
     }
     
+    // Verify that all textures are of the same size
+    for i in 1..<textures_list.count {
+        if (textures_list[0].width != textures_list[i].width)
+            || (textures_list[0].height != textures_list[i].height) {
+            throw AlignmentError.inconsistent_resolutions
+        }
+    }
+    
     return (textures_list, mosaic_pattern_width!)
 }
 


### PR DESCRIPTION
Changes: 
- Changed hotpixel_correction to lower its memory usage. It's now runs in two passes but remains deterministic. The two passes means it runs (slightly) slower, but it is insignificant compared to the rest (It's ~0.2% of the total run-time), while using a constant amount of memory instead of one that scales linearly with number of photos.
   - This change save `~N MB` of memory allocation where `N` is the total file size of the the images.
   - E.g. for seven 49MB images (~343MB total) and using NR=25, the total memory allocation goes from 2.32 GB to 1.90 GB
- Introduced re-usable buffers to significantly reduce total memory allocations/deallocations when using the frequency merge. Total app memory allocation changes:
    - `BEFORE: 16.6GB`
    - `AFTER:   5.3GB`
- Introduced a `add_crop` function so that the crop and addition in the frequency merge happens in one go.
- All merging operations done on 32 bit textures for simplicity


Leftover for separate PRs:
- Introduce re-used buffers to the spatial merging.
- See if the initial texture loading can convert them directly to floats so that `uint16_to_float` is not needed.
- See about changing the frequency merge so that the images are inset on a larger texture only once and the window on which the frequency merge is performed changes instead.

The way I'm testing is using the built in profiling tools:
1. Build for profiling and run in with the profiler
<img width="325" alt="Screenshot 2023-03-24 at 8 46 27 AM" src="https://user-images.githubusercontent.com/48962821/227525008-02a96532-7d5a-4343-9115-29e7476ea793.png">
2. Then choose to use the Allocations template.
<img width="82" alt="Screenshot 2023-03-24 at 8 47 56 AM" src="https://user-images.githubusercontent.com/48962821/227525273-280f262a-2da0-4cf0-a0d5-e98cffbf203b.png">
